### PR TITLE
修复Flask-SocketIO和gunicorn更新之后lepv与lepd通信失败的问题

### DIFF
--- a/app/run.py
+++ b/app/run.py
@@ -90,4 +90,4 @@ def test():
     return render_template("test.html", languages=languages)
 
 if __name__ == '__main__':
-    app.run(debug=True, host='0.0.0.0', port=8889)
+    socketio.run(app, debug=True, host='0.0.0.0', port=8889)

--- a/app/run.py
+++ b/app/run.py
@@ -1,3 +1,6 @@
+from gevent import monkey
+monkey.patch_all()
+
 from flask import Flask, render_template
 from flask_socketio import SocketIO, emit
 from app.modules.lepd.LepDClient import LepDClient


### PR DESCRIPTION
1.gunicorn的问题通过gevent自带的monkey patch修复。
2.Flask-SocketIO采用了新的run接口。